### PR TITLE
Updated PostgreSQL image version to 16 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - tyk
 
   tyk-postgres:
-    image: postgres:latest
+    image: postgres:16
     container_name: tyk-postgres
     environment:
       - POSTGRES_DB=tyk_analytics
@@ -69,7 +69,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
 
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]


### PR DESCRIPTION
Pin the pgres version - currently it uses `latest` which pulls pgres 18 and this breaks the install.