### PR TITLE
fix: run portal as root to resolve themes permission error in v1.17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - tyk
   tyk-ent-portal:
     image: tykio/portal:${PORTAL_VERSION:-v1.14.0}
+    user: "0"
     ports:
       - 3001:3001
     environment:


### PR DESCRIPTION
## Problem

Portal `v1.17` introduced a startup step that creates `/opt/portal/themes` at runtime. The image runs as UID `65532` (non-root) but `/opt/portal/` is root-owned inside the image, causing a fatal crash on boot:

```
theme bootstrap failed: unpacking default: mkdir /opt/portal/themes: permission denied
```

This breaks the [Getting Started with Tyk Self-Managed](https://tyk.io/docs/getting-started/quick-start) guide — the portal container exits immediately and bootstrap fails.

Verified against:
- Gateway/Dashboard: `v5.8.13`
- Portal: `v1.17.1`

## Fix

Add `user: "0"` to the `tyk-ent-portal` service to run as root until the portal image is fixed to pre-create `/opt/portal/themes` with the correct ownership (UID `65532`).

## Note

This is a stop-gap. The proper fix is in the portal image — the Dockerfile should `chown 65532 /opt/portal` or pre-create the `themes` directory during build. Once that's done, `user: "0"` can be removed.